### PR TITLE
Build with support for 2.12.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ val ScalatestVersion = "3.1.1"
 val appSettings = Seq(
     organization := Org,
     scalaVersion := "2.12.13",
-    crossScalaVersions := Seq("2.12.13", "2.13.0"),
+    crossScalaVersions := Seq("2.10.7", "2.11.12", "2.12.13", "2.13.0"),
     fork in Test := false,
     publishMavenStyle := true,
     publishArtifact in Test := false,
@@ -19,14 +19,12 @@ val appSettings = Seq(
     scalacOptions := Seq("-unchecked", "-deprecation", "-feature", "-encoding", "utf8"),
     concurrentRestrictions in Global += Tags.limit(Tags.Test, 1),
     useGpg := true,
-    credentials += Credentials(Path.userHome / ".artifactory.credentials"),
-    // publishTo := {
-    //   if (isSnapshot.value)
-    //     Some("snapshots" at "https://oss.sonatype.org/content/repositories/snapshots")
-    //   else
-    //     Some("releases" at "https://oss.sonatype.org/service/local/staging/deploy/maven2")
-    // },
-    publishTo := Some("releases" at "https://artifactory.twitter.biz/libs-releases-local"),
+    publishTo := {
+      if (isSnapshot.value)
+        Some("snapshots" at "https://oss.sonatype.org/content/repositories/snapshots")
+      else
+        Some("releases" at "https://oss.sonatype.org/service/local/staging/deploy/maven2")
+    },
     pomExtra := {
       <url>https://github.com/twitter-forks/scalac-scoverage-plugin</url>
         <licenses>

--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,7 @@ val appSettings = Seq(
     scalacOptions := Seq("-unchecked", "-deprecation", "-feature", "-encoding", "utf8"),
     concurrentRestrictions in Global += Tags.limit(Tags.Test, 1),
     useGpg := true,
+    credentials += Credentials(Path.userHome / ".sbt" / "sonatype_credentials"),
     publishTo := {
       if (isSnapshot.value)
         Some("snapshots" at "https://oss.sonatype.org/content/repositories/snapshots")

--- a/build.sbt
+++ b/build.sbt
@@ -6,12 +6,12 @@ import sbtcrossproject.CrossProject
 import sbtcrossproject.CrossType
 
 val Org = "com.twitter.scoverage"
-val ScalatestVersion = "3.0.8"
+val ScalatestVersion = "3.1.1"
 
 val appSettings = Seq(
     organization := Org,
-    scalaVersion := "2.12.8",
-    crossScalaVersions := Seq("2.10.7", "2.11.12", "2.12.8", "2.13.0"),
+    scalaVersion := "2.12.13",
+    crossScalaVersions := Seq("2.12.13", "2.13.0"),
     fork in Test := false,
     publishMavenStyle := true,
     publishArtifact in Test := false,
@@ -19,12 +19,14 @@ val appSettings = Seq(
     scalacOptions := Seq("-unchecked", "-deprecation", "-feature", "-encoding", "utf8"),
     concurrentRestrictions in Global += Tags.limit(Tags.Test, 1),
     useGpg := true,
-    publishTo := {
-      if (isSnapshot.value)
-        Some("snapshots" at "https://oss.sonatype.org/content/repositories/snapshots")
-      else
-        Some("releases" at "https://oss.sonatype.org/service/local/staging/deploy/maven2")
-    },
+    credentials += Credentials(Path.userHome / ".artifactory.credentials"),
+    // publishTo := {
+    //   if (isSnapshot.value)
+    //     Some("snapshots" at "https://oss.sonatype.org/content/repositories/snapshots")
+    //   else
+    //     Some("releases" at "https://oss.sonatype.org/service/local/staging/deploy/maven2")
+    // },
+    publishTo := Some("releases" at "https://artifactory.twitter.biz/libs-releases-local"),
     pomExtra := {
       <url>https://github.com/twitter-forks/scalac-scoverage-plugin</url>
         <licenses>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,6 +4,6 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.28")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.0.0")
 
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")

--- a/scalac-scoverage-plugin/src/test/scala/scoverage/ScoverageCompiler.scala
+++ b/scalac-scoverage-plugin/src/test/scala/scoverage/ScoverageCompiler.scala
@@ -69,7 +69,7 @@ object ScoverageCompiler {
   }
 }
 
-class ScoverageCompiler(settings: scala.tools.nsc.Settings, reporter: scala.tools.nsc.reporters.Reporter)
+class ScoverageCompiler(settings: scala.tools.nsc.Settings, reporter: scala.tools.nsc.reporters.FilteringReporter)
   extends scala.tools.nsc.Global(settings, reporter) {
 
   def addToClassPath(file: File): Unit = {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.2-twitter"
+version in ThisBuild := "1.0.3-twitter-dev0"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.3-twitter-dev0"
+version in ThisBuild := "1.0.3-twitter-dev1"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.3-twitter-dev1"
+version in ThisBuild := "1.0.3-twitter"


### PR DESCRIPTION
Problem
======

This fork needs support for scala 2.12.13 which breaks internal compiler apis in `scala.tools.nsc.reporters.*`. We are applying minimal change here to support scala 2.12.13. 

Solution
======

* Add 2.12.13 to cross build and  scalaVersion.
* Modify parameters where breaking API exists.
* Setup `sonatype_credentials`